### PR TITLE
style: ruff-format utils/stats.py (post-merge cleanup)

### DIFF
--- a/utils/stats.py
+++ b/utils/stats.py
@@ -240,6 +240,7 @@ def try_rliable_analysis(results: Dict[str, np.ndarray], output_dir: str):
     try:
         from rliable import library as rly
         from rliable import metrics as rly_metrics
+
         # ``plot_utils`` is imported to verify the full rliable install is
         # present (the caller later builds rliable plots via helper scripts);
         # we assign ``_`` to signal the availability check to ruff/linters.


### PR DESCRIPTION
One-line format fix: the squash-merge of #3 with Task 12 left a missing blank line in `utils/stats.py`, tripping `ruff format --check .` on main. This re-applies `ruff format` and brings `lint` back to green.

## Summary by Sourcery

Enhancements:
- Tidy stats utility formatting to conform to Ruff code style expectations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a `ruff` formatting violation in utils/stats.py by adding the required blank line after the `rliable` imports, restoring `ruff format --check .` to green.

<sup>Written for commit 69cbf0c02423ae9487f80a11bf37dccc6d36a17f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

